### PR TITLE
If response is empty, return empty array

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -127,6 +127,10 @@ export const davRequest = async (params: {
     },
     ignoreDeclaration: true,
   });
+  
+  if (typeof result.multistatus.response === 'undefined') {
+    return [];
+  }
 
   const responseBodies: RawResponse[] = Array.isArray(result.multistatus.response)
     ? result.multistatus.response


### PR DESCRIPTION
I wrote this in the GitHub code editor, so I haven't checked it for style, formatting, linting, etc. Adding this change manually to my node_modules does fix the issues I'm seeing. I now get back an empty `[]` to a request on an empty collection instead of the collection itself. Hopefully this fixes #75.