### PR TITLE
Add missing attribute to makeCalendar method

### DIFF
--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -85,7 +85,11 @@ export const makeCalendar = async (params: {
       namespace: DAVNamespaceShort.DAV,
       body: {
         [`${DAVNamespaceShort.CALDAV}:mkcalendar`]: {
-          _attributes: getDAVAttribute([DAVNamespace.DAV, DAVNamespace.CALDAV]),
+          _attributes: getDAVAttribute([
+            DAVNamespace.DAV,
+            DAVNamespace.CALDAV,
+            DAVNamespace.CALDAV_APPLE,
+          ]),
           set: {
             prop: props,
           },


### PR DESCRIPTION
Hi, there is missing attribute for makeCalendar method to for example to set calendar color like this:

```
  const result = await makeCalendar({
    url: 'https://caldav.icloud.com/12345676/calendars/c623f6be-a2d4-4c60-932a-043e67025dde/',
    props: {
      displayname: 'personal calendar',
      [`${DAVNamespaceShort.CALDAV}:calendar-description`]: 'calendar description',
      [`${DAVNamespaceShort.CALDAV_APPLE}:calendar-color`]: 'some color' 
    },
    headers: {
      authorization: 'Basic x0C9ueWd9Vz8OwS0DEAtkAlj',
    },
  });
```
Though don't know if other attributes would be useful here or only CALDAV_APPLE was missing.

Thanks
