### PR TITLE
Don't send <filter/> elements in calendar-multiget

### DIFF
--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -47,7 +47,6 @@ export const calendarMultiGet = async (params: {
   url: string;
   props: ElementCompact;
   objectUrls?: string[];
-  filters?: ElementCompact;
   timezone?: string;
   depth: DAVDepth;
   headers?: Record<string, string>;
@@ -60,7 +59,6 @@ export const calendarMultiGet = async (params: {
         _attributes: getDAVAttribute([DAVNamespace.DAV, DAVNamespace.CALDAV]),
         [`${DAVNamespaceShort.DAV}:prop`]: props,
         [`${DAVNamespaceShort.DAV}:href`]: objectUrls,
-        filter: filters,
         timezone,
       },
     },


### PR DESCRIPTION
Don't send <filter/> elements in calendar-multiget

This is not allowed by the CalDAV spec, see https://www.rfc-editor.org/rfc/rfc4791#page-63

Fixes nibdo/bloben-app#85
