### PR TITLE
Add `calendarColor` to `DAVCalendar` type

### DIFF
--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -76,4 +76,5 @@ export type DAVCalendar = {
   components?: string[];
   timezone?: string;
   projectedProps?: Record<string, unknown>;
+  calendarColor?: string;
 } & DAVCollection;


### PR DESCRIPTION
`calendarColor` is missing on typing of `DAVCalendar`

https://github.com/natelindev/tsdav/blob/21b81c7765bd548ec9735932954f9e13d1ca8c33/src/calendar.ts#L169-L186