### PR TITLE
Fix: Handle empty body responses in davRequest to prevent crash

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -88,7 +88,8 @@ export const davRequest = async (params: {
   if (
     !davResponse.ok ||
     !davResponse.headers.get('content-type')?.includes('xml') ||
-    !parseOutgoing
+    !parseOutgoing ||
+    !resText
   ) {
     return [
       {


### PR DESCRIPTION
This PR fixes a TypeError in the davRequest function that occurs when a DAV server returns a successful response (e.g., 201 Created) with an empty body.