### PR TITLE
fetchCalendars: accept calendars without supported-calendar-component-set

### DIFF
--- a/src/__tests__/unit/calendar.test.ts
+++ b/src/__tests__/unit/calendar.test.ts
@@ -375,6 +375,52 @@ describe('fetchCalendars', () => {
     expect(result).toHaveLength(1);
     expect(result[0].displayName).toBe('Good');
   });
+
+  it('should accept calendars when supported-calendar-component-set is missing', async () => {
+    // Some servers (e.g. Purelymail) violate RFC 4791 § 5.2.3 by not returning the
+    // supported-calendar-component-set property. The previous resourcetype filter has
+    // already confirmed these are calendar collections, so they should pass through.
+    mockedPropfind.mockResolvedValue([
+      {
+        href: '/cal/empty-prop/',
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        props: {
+          displayname: 'Empty Prop',
+          resourcetype: { calendar: {}, collection: {} },
+          // Server returned <supported-calendar-component-set/> with no children
+          supportedCalendarComponentSet: {},
+          getctag: 'c1',
+        },
+      },
+      {
+        href: '/cal/missing-prop/',
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        props: {
+          displayname: 'Missing Prop',
+          resourcetype: { calendar: {}, collection: {} },
+          // Property entirely absent from the response
+          getctag: 'c2',
+        },
+      },
+    ]);
+    mockedSupportedReportSet.mockResolvedValue([]);
+
+    const result = await fetchCalendars({
+      account: {
+        serverUrl: 'https://example.com/',
+        homeUrl: 'https://example.com/cal/',
+        rootUrl: 'https://example.com/',
+        accountType: 'caldav',
+      },
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result.map((c) => c.displayName)).toEqual(['Empty Prop', 'Missing Prop']);
+  });
 });
 
 describe('fetchCalendarUserAddresses', () => {

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -268,9 +268,16 @@ export const fetchCalendars = async (params?: {
     res
       .filter((r) => Object.keys(r.props?.resourcetype ?? {}).includes('calendar'))
       .filter((rc) => {
-        // filter out none iCal format calendars.
+        // Filter out non-iCal calendars when components are declared. Some servers
+        // (e.g. Purelymail) omit `supported-calendar-component-set` despite RFC 4791
+        // § 5.2.3 requiring it. When no usable component names come back, fall back to
+        // accepting the calendar — the previous filter already established it's a
+        // `<calendar/>` resourcetype, so we have independent evidence it's a calendar.
         const components = extractComponentNames(rc.props?.supportedCalendarComponentSet?.comp);
-        return components.some((c) => Object.values(ICALObjects).includes(c as ICALObjects));
+        return (
+          components.length === 0 ||
+          components.some((c) => Object.values(ICALObjects).includes(c as ICALObjects))
+        );
       })
       .map((rs) => {
         // debug(`Found calendar ${rs.props?.displayname}`);


### PR DESCRIPTION
## Summary

`fetchCalendars` currently filters out any calendar whose `supported-calendar-component-set` property is empty or absent. Real-world CalDAV servers do this in violation of [RFC 4791 § 5.2.3](https://datatracker.ietf.org/doc/html/rfc4791#section-5.2.3) — most notably **[Purelymail](https://purelymail.com)**, which returns an empty `<supported-calendar-component-set/>` element on every calendar collection.

The earlier filter (`Object.keys(resourcetype).includes('calendar')`) has already confirmed the resource is a calendar by the time we reach the component-set check, so the second filter is acting as belt-and-suspenders defense rather than primary identification. When the property is absent, falling back to "accept" matches what tolerant clients like Thunderbird/Lightning, Evolution-DS, and DAVx5 do in practice.

## Reproduction (against Purelymail)

```ts
import { DAVClient } from "tsdav";

const client = new DAVClient({
  serverUrl: "https://purelymail.com/",
  credentials: { username: "you@yours.com", password: "<app-password>" },
  authMethod: "Basic",
  defaultAccountType: "caldav",
});
await client.login();
console.log(await client.fetchCalendars());
// Before this PR: []
// After this PR: [{ url: "https://purelymail.com/webdav/<id>/caldav/default/", displayName: "Default", ... }]
```

`DEBUG=tsdav:*` confirms the full discovery chain succeeds (well-known redirect → principal → calendar-home-set) — only `fetchCalendars` swallows the actual calendar.

## Diff summary

- `src/calendar.ts`: when `extractComponentNames` returns an empty array, accept the calendar instead of rejecting it.
- `src/__tests__/unit/calendar.test.ts`: regression test with two fixtures — empty `supported-calendar-component-set` element (Purelymail's actual shape) and the property being entirely absent.

## Verification

- `pnpm test` — 186/186 unit tests pass (12 files), including 2 new fixtures.
- `pnpm typecheck` — clean.
- `pnpm lint` — clean for changed files (2 pre-existing errors in `src/account.ts` are unrelated to this PR).
- End-to-end against Purelymail's live CalDAV — `fetchCalendars()` now returns the `Default` calendar correctly; downstream `fetchCalendarObjects` and `freeBusyQuery` also work.

## Compatibility

- Existing test "should filter out non-iCal calendars" still passes — calendars that explicitly declare a non-iCal component (e.g. `UNKNOWN_TYPE`) still get filtered out. Only the absent/empty case changes behavior.
- No public API surface change; no opt-out flag added (happy to add one if you'd prefer to keep strict-by-default).